### PR TITLE
Update react-bootstrap to 0.31.0

### DIFF
--- a/00-Centralized-Login/package.json
+++ b/00-Centralized-Login/package.json
@@ -10,7 +10,7 @@
     "bootstrap": "^3.3.7",
     "events": "^1.1.1",
     "react": "^15.5.4",
-    "react-bootstrap": "^0.30.10",
+    "react-bootstrap": "^0.31.0",
     "react-dom": "^15.5.4",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1"

--- a/01-Embedded-Login/package.json
+++ b/01-Embedded-Login/package.json
@@ -11,7 +11,7 @@
     "events": "^1.1.1",
     "history": "^4.6.1",
     "react": "^15.5.4",
-    "react-bootstrap": "^0.30.10",
+    "react-bootstrap": "^0.31.0",
     "react-dom": "^15.5.4",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1"

--- a/02-Custom-Login-Form/package.json
+++ b/02-Custom-Login-Form/package.json
@@ -10,7 +10,7 @@
     "bootstrap": "^3.3.7",
     "events": "^1.1.1",
     "react": "^15.5.4",
-    "react-bootstrap": "^0.30.10",
+    "react-bootstrap": "^0.31.0",
     "react-dom": "^15.5.4",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1"

--- a/03-User-Profile/package.json
+++ b/03-User-Profile/package.json
@@ -11,7 +11,7 @@
     "events": "^1.1.1",
     "history": "^4.6.1",
     "react": "^15.5.4",
-    "react-bootstrap": "^0.30.10",
+    "react-bootstrap": "^0.31.0",
     "react-dom": "^15.5.4",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1"

--- a/04-Calling-API/package.json
+++ b/04-Calling-API/package.json
@@ -17,7 +17,7 @@
     "jwks-rsa": "^1.1.1",
     "npm-run-all": "^4.0.1",
     "react": "^15.4.2",
-    "react-bootstrap": "^0.30.7",
+    "react-bootstrap": "^0.31.0",
     "react-dom": "^15.4.2",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1"

--- a/05-Authorization/package.json
+++ b/05-Authorization/package.json
@@ -19,7 +19,7 @@
     "jwt-decode": "^2.1.0",
     "npm-run-all": "^4.0.1",
     "react": "^15.4.2",
-    "react-bootstrap": "^0.30.7",
+    "react-bootstrap": "^0.31.0",
     "react-dom": "^15.4.2",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1"

--- a/06-Centralized-Login-With-API/package.json
+++ b/06-Centralized-Login-With-API/package.json
@@ -17,7 +17,7 @@
     "jwks-rsa": "^1.1.1",
     "npm-run-all": "^4.0.1",
     "react": "^15.5.4",
-    "react-bootstrap": "^0.30.10",
+    "react-bootstrap": "^0.31.0",
     "react-dom": "^15.5.4",
     "react-router": "^4.1.1",
     "react-router-dom": "^4.1.1"


### PR DESCRIPTION
This fixes the console warnings about React.PropTypes and React.createClass