### PR TITLE
Add logging to the API server via morgan

### DIFF
--- a/03-Calling-an-API/package.json
+++ b/03-Calling-an-API/package.json
@@ -16,6 +16,7 @@
     "express-jwt-authz": "^1.0.0",
     "history": "^4.6.1",
     "jwks-rsa": "^1.1.1",
+    "morgan": "^1.8.2",
     "npm-run-all": "^4.0.1",
     "react": "^15.5.4",
     "react-bootstrap": "^0.31.0",

--- a/03-Calling-an-API/server.js
+++ b/03-Calling-an-API/server.js
@@ -4,6 +4,7 @@ const jwt = require('express-jwt');
 const jwtAuthz = require('express-jwt-authz');
 const jwksRsa = require('jwks-rsa');
 const cors = require('cors');
+const morgan = require('morgan');
 require('dotenv').config();
 
 if (!process.env.AUTH0_DOMAIN || !process.env.AUTH0_AUDIENCE) {
@@ -11,6 +12,7 @@ if (!process.env.AUTH0_DOMAIN || !process.env.AUTH0_AUDIENCE) {
 }
 
 app.use(cors());
+app.use(morgan('API Request (port 3001): :method :url :status :response-time ms - :res[content-length]'));
 
 const checkJwt = jwt({
   // Dynamically provide a signing key based on the kid in the header and the singing keys provided by the JWKS endpoint.


### PR DESCRIPTION
A custom morgan format is used so we can show that the API is listening on a different port than the web app.

Sample TTY output:

```
Compiled successfully!

The app is running at:

  http://localhost:3000/

Note that the development build is not optimized.
To create a production build, use yarn run build.

API Request (port 3001): GET /api/public 304 3.982 ms - -
API Request (port 3001): GET /api/private 304 347.072 ms - -
```