### PR TITLE
Fix blank screen when scopes not already defined

### DIFF
--- a/04-Authorization/src/Auth/Auth.js
+++ b/04-Authorization/src/Auth/Auth.js
@@ -98,7 +98,7 @@ export default class Auth {
   }
 
   userHasScopes(scopes) {
-    const grantedScopes = JSON.parse(localStorage.getItem('scopes')).split(' ');
+    const grantedScopes = (JSON.parse(localStorage.getItem('scopes')) || '').split(' ');
     return scopes.every(scope => grantedScopes.includes(scope));
   }
 }


### PR DESCRIPTION
When a user runs the 04 - Authorization sample, it errors out because `scopes` is not defined in localStorage, causing a blank screen.

This would happen if the user is already logged in because he previously tried one of the other samples.