### PR TITLE
Use render instead of ReactDOM.render for optimization

### DIFF
--- a/01-Login/package.json
+++ b/01-Login/package.json
@@ -6,7 +6,7 @@
     "react-scripts": "0.9.5"
   },
   "dependencies": {
-    "auth0-js": "^8.8.0",
+    "auth0-js": "^8.9.0",
     "bootstrap": "^3.3.7",
     "react": "^15.5.4",
     "react-bootstrap": "^0.31.0",

--- a/01-Login/src/index.js
+++ b/01-Login/src/index.js
@@ -1,11 +1,11 @@
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 import './index.css';
 import 'bootstrap/dist/css/bootstrap.css';
 import { makeMainRoutes } from './routes';
 
 const routes = makeMainRoutes();
 
-ReactDOM.render(
+render(
   routes,
   document.getElementById('root')
 );

--- a/02-User-Profile/package.json
+++ b/02-User-Profile/package.json
@@ -6,7 +6,7 @@
     "react-scripts": "0.9.5"
   },
   "dependencies": {
-    "auth0-js": "^8.8.0",
+    "auth0-js": "^8.9.0",
     "bootstrap": "^3.3.7",
     "history": "^4.6.1",
     "react": "^15.5.4",

--- a/02-User-Profile/src/index.js
+++ b/02-User-Profile/src/index.js
@@ -1,11 +1,11 @@
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 import './index.css';
 import 'bootstrap/dist/css/bootstrap.css';
 import { makeMainRoutes } from './routes';
 
 const routes = makeMainRoutes();
 
-ReactDOM.render(
+render(
   routes,
   document.getElementById('root')
 );

--- a/03-Calling-an-API/package.json
+++ b/03-Calling-an-API/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "axios": "^0.16.2",
-    "auth0-js": "^8.8.0",
+    "auth0-js": "^8.9.0",
     "bootstrap": "^3.3.7",
     "cors": "^2.8.1",
     "dotenv": "^4.0.0",

--- a/03-Calling-an-API/src/index.js
+++ b/03-Calling-an-API/src/index.js
@@ -1,11 +1,11 @@
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 import './index.css';
 import 'bootstrap/dist/css/bootstrap.css';
 import { makeMainRoutes } from './routes';
 
 const routes = makeMainRoutes();
 
-ReactDOM.render(
+render(
   routes,
   document.getElementById('root')
 );

--- a/04-Authorization/package.json
+++ b/04-Authorization/package.json
@@ -6,7 +6,7 @@
     "react-scripts": "0.9.5"
   },
   "dependencies": {
-    "auth0-js": "^8.7.0",
+    "auth0-js": "^8.9.0",
     "axios": "^0.16.2",
     "bootstrap": "^3.3.7",
     "cors": "^2.8.3",

--- a/04-Authorization/src/index.js
+++ b/04-Authorization/src/index.js
@@ -1,11 +1,11 @@
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 import './index.css';
 import 'bootstrap/dist/css/bootstrap.css';
 import { makeMainRoutes } from './routes';
 
 const routes = makeMainRoutes();
 
-ReactDOM.render(
+render(
   routes,
   document.getElementById('root')
 );

--- a/05-Token-Renewal/package.json
+++ b/05-Token-Renewal/package.json
@@ -6,7 +6,7 @@
     "react-scripts": "1.0.10"
   },
   "dependencies": {
-    "auth0-js": "^8.8.0",
+    "auth0-js": "^8.9.0",
     "bootstrap": "^3.3.7",
     "connect-static-file": "^1.2.0",
     "cors": "^2.8.4",

--- a/05-Token-Renewal/src/index.js
+++ b/05-Token-Renewal/src/index.js
@@ -1,11 +1,11 @@
-import ReactDOM from 'react-dom';
+import { render } from 'react-dom';
 import './index.css';
 import 'bootstrap/dist/css/bootstrap.css';
 import { makeMainRoutes } from './routes';
 
 const routes = makeMainRoutes();
 
-ReactDOM.render(
+render(
   routes,
   document.getElementById('root')
 );


### PR DESCRIPTION
I propose this because of webpack (tree shaking) part, this way we are only loading the render() function not the entire ReactDOM package, giving a hint to webpack that other parts of ReactDOM is not required, selectively loading only the pieces we need, also code looks declarative and intuitive :)