### PR TITLE
facillitation to pass AuthResult vars as props to routed components 

### DIFF
--- a/01-Login/src/Auth/Auth.js
+++ b/01-Login/src/Auth/Auth.js
@@ -23,24 +23,9 @@ export default class Auth {
     this.auth0.authorize();
   }
 
-  handleAuthentication() {
-    this.auth0.parseHash((err, authResult) => {
-      if (authResult && authResult.accessToken && authResult.idToken) {
-        this.setSession(authResult);
-        history.replace('/home');
-      } else if (err) {
-        history.replace('/home');
-        console.log(err);
-        alert(`Error: ${err.error}. Check the console for further details.`);
-      }
-    });
-  }
-
   setSession(authResult) {
     // Set the time that the access token will expire at
     let expiresAt = JSON.stringify((authResult.expiresIn * 1000) + new Date().getTime());
-    localStorage.setItem('access_token', authResult.accessToken);
-    localStorage.setItem('id_token', authResult.idToken);
     localStorage.setItem('expires_at', expiresAt);
     // navigate to the home route
     history.replace('/home');
@@ -48,8 +33,6 @@ export default class Auth {
 
   logout() {
     // Clear access token and ID token from local storage
-    localStorage.removeItem('access_token');
-    localStorage.removeItem('id_token');
     localStorage.removeItem('expires_at');
     // navigate to the home route
     history.replace('/home');

--- a/01-Login/src/Auth/auth0-variables.example.js
+++ b/01-Login/src/Auth/auth0-variables.example.js
@@ -1,0 +1,5 @@
+export const AUTH_CONFIG = {
+  domain: '{DOMAIN}', 
+  clientId: '{CLIENT_ID}', 
+  callbackUrl: 'http://localhost:3000/callback'
+}

--- a/01-Login/src/Auth/auth0-variables.js.example
+++ b/01-Login/src/Auth/auth0-variables.js.example
@@ -1,5 +1,0 @@
-export const AUTH_CONFIG = {
-  domain: '{DOMAIN}',
-  clientId: '{CLIENT_ID}',
-  callbackUrl: 'http://localhost:3000/callback'
-}

--- a/01-Login/src/index.js
+++ b/01-Login/src/index.js
@@ -1,11 +1,10 @@
+import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import 'bootstrap/dist/css/bootstrap.css';
-import { makeMainRoutes } from './routes';
-
-const routes = makeMainRoutes();
+import Routes from './routes';
 
 ReactDOM.render(
-  routes,
+  <Routes />,
   document.getElementById('root')
 );

--- a/01-Login/src/routes.js
+++ b/01-Login/src/routes.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { Route, Router } from 'react-router-dom';
 import App from './App';
 import Home from './Home/Home';
@@ -6,25 +6,47 @@ import Callback from './Callback/Callback';
 import Auth from './Auth/Auth';
 import history from './history';
 
-const auth = new Auth();
+export default class Routes extends Component {
+  constructor(){
+    super();
 
-const handleAuthentication = (nextState, replace) => {
-  if (/access_token|id_token|error/.test(nextState.location.hash)) {
-    auth.handleAuthentication();
+    this.auth = new Auth();
+
+    this.state = {
+      user_id: null
+    };
   }
-}
 
-export const makeMainRoutes = () => {
-  return (
-      <Router history={history} component={App}>
-        <div>
-          <Route path="/" render={(props) => <App auth={auth} {...props} />} />
-          <Route path="/home" render={(props) => <Home auth={auth} {...props} />} />
-          <Route path="/callback" render={(props) => {
-            handleAuthentication(props);
-            return <Callback {...props} /> 
-          }}/>
-        </div>
-      </Router>
-  );
+  handleAuthentication = (nextState, replace) => {
+    if (/access_token|id_token|error/.test(nextState.location.hash)) {
+      const { auth0 } = this.auth;
+      auth0.parseHash((err, authResult) => {
+        if (authResult && authResult.accessToken && authResult.idToken) {
+          this.auth.setSession(authResult);
+          // persist logged-in user_id (and/or other variables) in state to pass to child components
+          this.setState({user_id: authResult.idTokenPayload.sub})
+          history.replace('/home');
+        } else if (err) {
+          history.replace('/home');
+          console.log(err);
+          alert(`Error: ${err.error}. Check the console for further details.`);
+        }
+      });
+    }
+  }
+  
+  render() {
+    return (
+        <Router history={history} component={App}>
+          <div>
+            <Route path="/" render={(props) => <App auth={this.auth} {...props} {...this.state} />} />
+            <Route path="/home" render={(props) => <Home auth={this.auth} {...props} {...this.state}/>} />
+            <Route path="/callback" render={(props) => {
+              this.handleAuthentication(props);
+              return <Callback {...props} /> 
+            }}/>
+          </div>
+        </Router>
+    );
+  }
 }


### PR DESCRIPTION
To encourage Reactjs best practices auth params should not be read from local storage but passed to routed components via props. Extract this functionality from Auth.js, move it to a refactored Routes.js (class) and pass incoming user_id from the AuthResult to routed components as props as demonstration of downstream auth flow in React using state and props.

While the existing implementation is very functional, it was confusing to me why it wasn't implemented in the spirit of passing props between components. Also the tutorial implementation set me down the path of believing that reading auth vars from local storage was common, best practice which I don't believe is something an Auth0 tutorial should be suggesting. /shrug
