### PR TITLE
:lipstick: refactor handleAuthentication definition

### DIFF
--- a/01-Login/src/routes.js
+++ b/01-Login/src/routes.js
@@ -8,8 +8,8 @@ import history from './history';
 
 const auth = new Auth();
 
-const handleAuthentication = (nextState, replace) => {
-  if (/access_token|id_token|error/.test(nextState.location.hash)) {
+const handleAuthentication = ({location}) => {
+  if (/access_token|id_token|error/.test(location.hash)) {
     auth.handleAuthentication();
   }
 }

--- a/02-User-Profile/src/routes.js
+++ b/02-User-Profile/src/routes.js
@@ -9,8 +9,8 @@ import history from './history';
 
 const auth = new Auth();
 
-const handleAuthentication = (nextState, replace) => {
-  if (/access_token|id_token|error/.test(nextState.location.hash)) {
+const handleAuthentication = ({location}) => {
+  if (/access_token|id_token|error/.test(location.hash)) {
     auth.handleAuthentication();
   }
 }

--- a/03-Calling-an-API/src/routes.js
+++ b/03-Calling-an-API/src/routes.js
@@ -10,8 +10,8 @@ import history from './history';
 
 const auth = new Auth();
 
-const handleAuthentication = (nextState, replace) => {
-  if (/access_token|id_token|error/.test(nextState.location.hash)) {
+const handleAuthentication = ({location}) => {
+  if (/access_token|id_token|error/.test(location.hash)) {
     auth.handleAuthentication();
   }
 }

--- a/04-Authorization/src/routes.js
+++ b/04-Authorization/src/routes.js
@@ -11,8 +11,8 @@ import history from './history';
 
 const auth = new Auth();
 
-const handleAuthentication = (nextState, replace) => {
-  if (/access_token|id_token|error/.test(nextState.location.hash)) {
+const handleAuthentication = ({location}) => {
+  if (/access_token|id_token|error/.test(location.hash)) {
     auth.handleAuthentication();
   }
 }

--- a/05-Token-Renewal/src/routes.js
+++ b/05-Token-Renewal/src/routes.js
@@ -9,8 +9,8 @@ import history from './history';
 
 const auth = new Auth();
 
-const handleAuthentication = (nextState, replace) => {
-  if (/access_token|id_token|error/.test(nextState.location.hash)) {
+const handleAuthentication = ({location}) => {
+  if (/access_token|id_token|error/.test(location.hash)) {
     auth.handleAuthentication();
   }
 };


### PR DESCRIPTION
This commit removes the second parameter of the handleAuthentication method, as it is never used
and refactor the first argument to use ES6 destructuring for clear description of
what is the subject of the method implementation. The *nextState* has been replaced
with `location` object directly as the subject of the method check

Thanks!