### PR TITLE
Fix custom login form step to call cross-origin authentication

### DIFF
--- a/02-Custom-Login-Form/src/Auth/Auth.js
+++ b/02-Custom-Login-Form/src/Auth/Auth.js
@@ -21,28 +21,38 @@ export default class Auth {
   }
 
   login(username, password) {
-    this.auth0.client.login(
-      { realm: 'Username-Password-Authentication', username, password },
+    this.auth0.login(
+      { realm: AUTH_CONFIG.dbConnectionName, username, password },
       (err, authResult) => {
         if (err) {
           console.log(err);
           alert(`Error: ${err.description}. Check the console for further details.`);
           return;
         }
-        this.setSession(authResult);
       }
     );
   }
 
   signup(email, password) {
-    this.auth0.redirect.signupAndLogin(
-      { connection: 'Username-Password-Authentication', email, password },
-      function(err) {
+    this.auth0.signup(
+      { connection: AUTH_CONFIG.dbConnectionName, email, password },
+      (err) => {
         if (err) {
           console.log(err);
           alert(`Error: ${err.description}. Check the console for further details.`);
+
           return;
         }
+
+        this.auth0.login({ realm: AUTH_CONFIG.dbConnectionName, username: email, password },
+          (err, authResult) => {
+            if (err) {
+              console.log(err);
+              alert(`Error: ${err.description}. Check the console for further details.`);
+              return;
+            }
+          }
+        );
       }
     );
   }

--- a/02-Custom-Login-Form/src/Auth/auth0-variables.js.example
+++ b/02-Custom-Login-Form/src/Auth/auth0-variables.js.example
@@ -1,5 +1,6 @@
 export const AUTH_CONFIG = {
   domain: '{DOMAIN}',
   clientId: '{CLIENT_ID}',
-  callbackUrl: 'http://localhost:3000/callback'
+  callbackUrl: 'http://localhost:3000/callback',
+  dbConnectionName: 'Username-Password-Authentication',
 }


### PR DESCRIPTION
The previous login method was using `client.login` instead of just the `login` method which meant that ROPC grant was being attempted instead of cross-origin.

Also updated the signup method to do the signup call followed by a cross-origin authentication login so that everything uses the same methodology.