### PR TITLE
use proper lifecycle method

### DIFF
--- a/02-User-Profile/src/Profile/Profile.js
+++ b/02-User-Profile/src/Profile/Profile.js
@@ -3,7 +3,11 @@ import { Panel, ControlLabel, Glyphicon } from 'react-bootstrap';
 import './Profile.css';
 
 class Profile extends Component {
-  componentWillMount() {
+  constructor() {
+    super();
+    this.state = { profile: {} };
+  }
+  componentDidMount() {
     this.setState({ profile: {} });
     const { userProfile, getProfile } = this.props.auth;
     if (!userProfile) {


### PR DESCRIPTION
Now the state is only updated after the component is mounted.

From the [docs](https://reactjs.org/docs/react-component.html#componentwillmount):
>You should not call setState() in componentWillUnmount() because the component will never be re-rendered. Once a component instance is unmounted, it will never be mounted again.