### PR TITLE
fix ping header example

### DIFF
--- a/03-Calling-an-API/src/Ping/Ping.js
+++ b/03-Calling-an-API/src/Ping/Ping.js
@@ -13,8 +13,8 @@ class Ping extends Component {
       .catch(error => this.setState({ message: error.message }));
   }
   securedPing() {
-    const { getAccessToken } = this.props.auth;
-    const headers = { 'Authorization': `Bearer ${getAccessToken()}`}
+    const { getIdToken } = this.props.auth;
+    const headers = { 'Authorization': `Bearer ${getIdToken()}`}
     axios.get(`${API_URL}/private`, { headers })
       .then(response => this.setState({ message: response.data.message }))
       .catch(error => this.setState({ message: error.message }));


### PR DESCRIPTION
the example is using the getAccessToken method which returns the access token which is not a valid jwt token. 

Instead we need to use the getIdToken method to get the valid auth header.