### PR TITLE
Add missing auth0-variables example from tutorial 05

### DIFF
--- a/05-Token-Renewal/src/Auth/auth0-variables.js.example
+++ b/05-Token-Renewal/src/Auth/auth0-variables.js.example
@@ -1,0 +1,5 @@
+export const AUTH_CONFIG = {
+  domain: '{DOMAIN}',
+  clientId: '{CLIENT_ID}',
+  callbackUrl: 'http://localhost:3000/callback'
+}


### PR DESCRIPTION
The `auth0-variables.js.example` file is missing from tutorial 05-token-renewal. Adding it so it matches the tutorial as described on auth0.com as well as in the README.