### PR TITLE
Update History.js

### DIFF
--- a/01-Login/src/history.js
+++ b/01-Login/src/history.js
@@ -1,3 +1,3 @@
-import createHistory from 'history/createBrowserHistory'
+import { createBrowserHistory as createHistory } from 'history';
 
 export default createHistory()


### PR DESCRIPTION
ReactTraining/history will be changing its required import statement to use its package. 

Please update code accordingly to conform for the next update.

```
warnAboutDeprecatedCJSRequire.js:17 Warning: Please use `require("history").createBrowserHistory` instead of `require("history/createBrowserHistory")`. Support for the latter will be removed in the next major release.
```