### PR TITLE
Refactored usage of redirect_uri

### DIFF
--- a/01-Login/src/components/NavBar.js
+++ b/01-Login/src/components/NavBar.js
@@ -58,11 +58,7 @@ const NavBar = () => {
                     id="qsLoginBtn"
                     color="primary"
                     className="btn-margin"
-                    onClick={() =>
-                      loginWithRedirect({
-                        redirect_uri: window.location.origin
-                      })
-                    }
+                    onClick={() => loginWithRedirect({})}
                   >
                     Log in
                   </Button>

--- a/01-Login/src/components/PrivateRoute.js
+++ b/01-Login/src/components/PrivateRoute.js
@@ -10,7 +10,6 @@ const PrivateRoute = ({ component: Component, path, ...rest }) => {
     const fn = async () => {
       if (!isAuthenticated) {
         await loginWithRedirect({
-          redirect_uri: window.location.origin,
           appState: { targetUrl: path }
         });
       }

--- a/01-Login/src/index.js
+++ b/01-Login/src/index.js
@@ -20,6 +20,7 @@ ReactDOM.render(
   <Auth0Provider
     domain={config.domain}
     client_id={config.clientId}
+    redirect_uri={window.location.origin}
     onRedirectCallback={onRedirectCallback}
   >
     <App />

--- a/02-Calling-an-API/src/components/NavBar.js
+++ b/02-Calling-an-API/src/components/NavBar.js
@@ -70,11 +70,7 @@ const NavBar = () => {
                     id="qsLoginBtn"
                     color="primary"
                     className="btn-margin"
-                    onClick={() =>
-                      loginWithRedirect({
-                        redirect_uri: window.location.origin
-                      })
-                    }
+                    onClick={() => loginWithRedirect({})}
                   >
                     Log in
                   </Button>

--- a/02-Calling-an-API/src/components/PrivateRoute.js
+++ b/02-Calling-an-API/src/components/PrivateRoute.js
@@ -10,7 +10,6 @@ const PrivateRoute = ({ component: Component, path, ...rest }) => {
     const fn = async () => {
       if (!isAuthenticated) {
         await loginWithRedirect({
-          redirect_uri: window.location.origin,
           appState: { targetUrl: path }
         });
       }

--- a/02-Calling-an-API/src/index.js
+++ b/02-Calling-an-API/src/index.js
@@ -21,6 +21,7 @@ ReactDOM.render(
     domain={config.domain}
     client_id={config.clientId}
     audience={config.audience}
+    redirect_uri={window.location.origin}
     onRedirectCallback={onRedirectCallback}
   >
     <App />


### PR DESCRIPTION
Moved the redirect_uri assigment to the creation of the Auth0Provider so
that it doesn't have to be specified everywhere `loginWithRedirect` is
used.