### PR TITLE
Move createContext call from React class to object destructuring.

### DIFF
--- a/01-Login/src/react-auth0-spa.js
+++ b/01-Login/src/react-auth0-spa.js
@@ -1,10 +1,10 @@
-import React, { useState, useEffect, useContext } from "react";
-import createAuth0Client from "@auth0/auth0-spa-js";
+import React, { createContext, useState, useEffect, useContext } from 'react';
+import createAuth0Client from '@auth0/auth0-spa-js';
 
 const DEFAULT_REDIRECT_CALLBACK = () =>
   window.history.replaceState({}, document.title, window.location.pathname);
 
-export const Auth0Context = React.createContext();
+export const Auth0Context = createContext();
 export const useAuth0 = () => useContext(Auth0Context);
 export const Auth0Provider = ({
   children,
@@ -22,7 +22,7 @@ export const Auth0Provider = ({
       const auth0FromHook = await createAuth0Client(initOptions);
       setAuth0(auth0FromHook);
 
-      if (window.location.search.includes("code=")) {
+      if (window.location.search.includes('code=')) {
         const { appState } = await auth0FromHook.handleRedirectCallback();
         onRedirectCallback(appState);
       }


### PR DESCRIPTION
Hi, I think its better call createContext function from the destructuring assignment, is more easy to understand the code.