### PR TITLE
Removed theme as NPM package in favor of CDN link

### DIFF
--- a/01-Login/package.json
+++ b/01-Login/package.json
@@ -20,8 +20,7 @@
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.0.0",
     "react-scripts": "3.0.0",
-    "reactstrap": "^8.0.0",
-    "samples-bootstrap-theme": "github:auth0-quickstarts/samples-bootstrap-theme"
+    "reactstrap": "^8.0.0"
   },
   "devDependencies": {},
   "eslintConfig": {

--- a/01-Login/public/index.html
+++ b/01-Login/public/index.html
@@ -30,6 +30,11 @@
       crossorigin="anonymous"
     />
 
+    <link
+      rel="stylesheet"
+      href="https://cdn.auth0.com/js/auth0-samples-theme/1.0/css/auth0-theme.min.css"
+    />
+
     <title>Login</title>
   </head>
   <body class="h-100">

--- a/01-Login/src/App.js
+++ b/01-Login/src/App.js
@@ -11,7 +11,6 @@ import Profile from "./views/Profile";
 import { useAuth0 } from "./react-auth0-spa";
 
 // styles
-import "samples-bootstrap-theme/dist/css/auth0-theme.css";
 import "./App.css";
 
 // fontawesome

--- a/01-Login/yarn.lock
+++ b/01-Login/yarn.lock
@@ -8625,10 +8625,6 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-"samples-bootstrap-theme@github:auth0-quickstarts/samples-bootstrap-theme":
-  version "0.5.1"
-  resolved "https://codeload.github.com/auth0-quickstarts/samples-bootstrap-theme/tar.gz/22a1f6a8950268dd9b68f5723675da6820133149"
-
 sane@^4.0.3:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-4.1.0.tgz#ed881fd922733a6c461bc189dc2b6c006f3ffded"

--- a/02-Calling-an-API/package.json
+++ b/02-Calling-an-API/package.json
@@ -28,8 +28,7 @@
     "react-dom": "^16.8.6",
     "react-router-dom": "^5.0.0",
     "react-scripts": "3.0.0",
-    "reactstrap": "^8.0.0",
-    "samples-bootstrap-theme": "github:auth0-quickstarts/samples-bootstrap-theme"
+    "reactstrap": "^8.0.0"
   },
   "devDependencies": {
     "nodemon": "^1.19.0"

--- a/02-Calling-an-API/public/index.html
+++ b/02-Calling-an-API/public/index.html
@@ -29,6 +29,11 @@
       crossorigin="anonymous"
     />
 
+    <link
+      rel="stylesheet"
+      href="https://cdn.auth0.com/js/auth0-samples-theme/1.0/css/auth0-theme.min.css"
+    />
+
     <title>Calling an API</title>
   </head>
   <body class="h-100">

--- a/02-Calling-an-API/src/App.js
+++ b/02-Calling-an-API/src/App.js
@@ -12,7 +12,6 @@ import ExternalApi from "./views/ExternalApi";
 import { useAuth0 } from "./react-auth0-spa";
 
 // styles
-import "samples-bootstrap-theme/dist/css/auth0-theme.css";
 import "./App.css";
 
 // fontawesome

--- a/02-Calling-an-API/yarn.lock
+++ b/02-Calling-an-API/yarn.lock
@@ -9218,10 +9218,6 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-"samples-bootstrap-theme@github:auth0-quickstarts/samples-bootstrap-theme":
-  version "0.5.1"
-  resolved "https://codeload.github.com/auth0-quickstarts/samples-bootstrap-theme/tar.gz/22a1f6a8950268dd9b68f5723675da6820133149"
-
 sane@^4.0.3:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/sane/-/sane-4.1.0.tgz#ed881fd922733a6c461bc189dc2b6c006f3ffded"


### PR DESCRIPTION
In preparation for https://github.com/auth0-quickstarts/samples-bootstrap-theme/pull/4