### PR TITLE
Pass props from PrivateRoute for isAuthenticated and idToken.

### DIFF
--- a/01-Login/src/components/PrivateRoute.js
+++ b/01-Login/src/components/PrivateRoute.js
@@ -5,7 +5,7 @@ import { useAuth0 } from "../react-auth0-spa";
 
 const PrivateRoute = ({ component: Component, path, ...rest }) => {
   const { isAuthenticated, loginWithRedirect } = useAuth0();
-
+  const [token, setToken] = useState();
   useEffect(() => {
     const fn = async () => {
       if (!isAuthenticated) {
@@ -16,9 +16,18 @@ const PrivateRoute = ({ component: Component, path, ...rest }) => {
     };
     fn();
   }, [isAuthenticated, loginWithRedirect, path]);
+  
+  useEffect(() => {
+    const fn = async () => {
+        const token = await getTokenSilently();
+        setToken(token);
+    };
+    fn();
+},[token]);
 
   const render = props =>
-    isAuthenticated === true ? <Component {...props} /> : null;
+    isAuthenticated === true ? <Component {...props} idToken={token}
+    isAuthenticated={isAuthenticated}/> : null;
 
   return <Route path={path} render={render} {...rest} />;
 };

--- a/02-Calling-an-API/src/components/PrivateRoute.js
+++ b/02-Calling-an-API/src/components/PrivateRoute.js
@@ -1,11 +1,11 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import { Route } from "react-router-dom";
 import { useAuth0 } from "../react-auth0-spa";
 
 const PrivateRoute = ({ component: Component, path, ...rest }) => {
   const { isAuthenticated, loginWithRedirect } = useAuth0();
-
+  const [token, setToken] = useState();
   useEffect(() => {
     const fn = async () => {
       if (!isAuthenticated) {
@@ -16,11 +16,18 @@ const PrivateRoute = ({ component: Component, path, ...rest }) => {
     };
     fn();
   }, [isAuthenticated, loginWithRedirect, path]);
-
-  if (!isAuthenticated) return null;
+  
+  useEffect(() => {
+    const fn = async () => {
+        const token = await getTokenSilently();
+        setToken(token);
+    };
+    fn();
+},[token]);
 
   const render = props =>
-    isAuthenticated === true ? <Component {...props} /> : null;
+    isAuthenticated === true ? <Component {...props} idToken={token}
+    isAuthenticated={isAuthenticated}/> : null;
 
   return <Route path={path} render={render} {...rest} />;
 };

--- a/02-Calling-an-API/src/views/ExternalApi.js
+++ b/02-Calling-an-API/src/views/ExternalApi.js
@@ -1,20 +1,17 @@
 import React, { useState } from "react";
 import { Button } from "reactstrap";
 import Highlight from "../components/Highlight";
-import { useAuth0 } from "../react-auth0-spa";
 
-const ExternalApi = () => {
+const ExternalApi = ({idToken}) => {
   const [showResult, setShowResult] = useState(false);
   const [apiMessage, setApiMessage] = useState("");
-  const { getTokenSilently } = useAuth0();
 
   const callApi = async () => {
     try {
-      const token = await getTokenSilently();
-
+      
       const response = await fetch("/api/external", {
         headers: {
-          Authorization: `Bearer ${token}`
+          Authorization: `Bearer ${idToken}`
         }
       });
 


### PR DESCRIPTION
ExternalApi can then be simpler and be a little more React-like - using props passed by the enclosing PrivateRoute component. 

Just a suggestion.



