### PR TITLE
use react router history.push instead of window.history.replaceState

### DIFF
--- a/01-Login/src/App.js
+++ b/01-Login/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { Router, Route, Switch } from "react-router-dom";
 import { Container } from "reactstrap";
 
 import PrivateRoute from "./components/PrivateRoute";
@@ -9,6 +9,7 @@ import Footer from "./components/Footer";
 import Home from "./views/Home";
 import Profile from "./views/Profile";
 import { useAuth0 } from "./react-auth0-spa";
+import history from "./utils/history";
 
 // styles
 import "./App.css";
@@ -25,7 +26,7 @@ const App = () => {
   }
 
   return (
-    <Router>
+    <Router history={history}>
       <div id="app" className="d-flex flex-column h-100">
         <NavBar />
         <Container className="flex-grow-1 mt-5">

--- a/01-Login/src/index.js
+++ b/01-Login/src/index.js
@@ -5,11 +5,10 @@ import App from "./App";
 import * as serviceWorker from "./serviceWorker";
 import { Auth0Provider } from "./react-auth0-spa";
 import config from "./auth_config.json";
+import history from "./utils/history";
 
 const onRedirectCallback = appState => {
-  window.history.replaceState(
-    {},
-    document.title,
+  history.push(
     appState && appState.targetUrl
       ? appState.targetUrl
       : window.location.pathname

--- a/01-Login/src/utils/history.js
+++ b/01-Login/src/utils/history.js
@@ -1,0 +1,2 @@
+import { createBrowserHistory } from "history";
+export default createBrowserHistory();

--- a/02-Calling-an-API/src/App.js
+++ b/02-Calling-an-API/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import { Router, Route, Switch } from "react-router-dom";
 import { Container } from "reactstrap";
 
 import PrivateRoute from "./components/PrivateRoute";
@@ -10,6 +10,7 @@ import Home from "./views/Home";
 import Profile from "./views/Profile";
 import ExternalApi from "./views/ExternalApi";
 import { useAuth0 } from "./react-auth0-spa";
+import history from "./utils/history";
 
 // styles
 import "./App.css";
@@ -26,7 +27,7 @@ const App = () => {
   }
 
   return (
-    <Router>
+    <Router history={history}>
       <div id="app" className="d-flex flex-column h-100">
         <NavBar />
         <Container className="flex-grow-1 mt-5">

--- a/02-Calling-an-API/src/index.js
+++ b/02-Calling-an-API/src/index.js
@@ -5,11 +5,10 @@ import App from "./App";
 import * as serviceWorker from "./serviceWorker";
 import { Auth0Provider } from "./react-auth0-spa";
 import config from "./auth_config.json";
+import history from "./utils/history";
 
 const onRedirectCallback = appState => {
-  window.history.replaceState(
-    {},
-    document.title,
+  history.push(
     appState && appState.targetUrl
       ? appState.targetUrl
       : window.location.pathname

--- a/02-Calling-an-API/src/utils/history.js
+++ b/02-Calling-an-API/src/utils/history.js
@@ -1,0 +1,2 @@
+import { createBrowserHistory } from "history";
+export default createBrowserHistory();


### PR DESCRIPTION
When trying to access a private route before logging in you are directed to Auth0's login screen. After successfully logging in you are then redirected back to the React application. The React application currently uses `window.history.replaceState`, which doesn't allow the private route's component to render. This is because we're using React Router. React Router prefers we do things its way, using `history`: https://github.com/ReactTraining/react-router/blob/master/FAQ.md#how-do-i-access-the-history-object-outside-of-components