### PR TITLE
Fix typo in Hero.js

### DIFF
--- a/01-Login/src/components/Hero.js
+++ b/01-Login/src/components/Hero.js
@@ -9,7 +9,7 @@ const Hero = () => (
 
     <p className="lead">
       This is a sample application that demonstrates an authentication flow for
-      an SPA, using <a href="https://reactjs.org">React.js</a>
+      a SPA, using <a href="https://reactjs.org">React.js</a>
     </p>
   </div>
 );


### PR DESCRIPTION
Should be "a SPA," not "an SPA."