### PR TITLE
Preventing logins on timeout

### DIFF
--- a/01-Login/src/react-auth0-spa.js
+++ b/01-Login/src/react-auth0-spa.js
@@ -51,6 +51,10 @@ export const Auth0Provider = ({
       await auth0Client.loginWithPopup(params);
     } catch (error) {
       console.error(error);
+      if (error.popup) {
+        error.popup.close();
+      }
+      return;
     } finally {
       setPopupOpen(false);
     }

--- a/02-Calling-an-API/src/react-auth0-spa.js
+++ b/02-Calling-an-API/src/react-auth0-spa.js
@@ -52,6 +52,10 @@ export const Auth0Provider = ({
       await auth0Client.loginWithPopup(params);
     } catch (error) {
       console.error(error);
+      if (error.popup) {
+        error.popup.close();
+      }
+      return;
     } finally {
       setPopupOpen(false);
     }


### PR DESCRIPTION
Issue:
- if the `loginWithPopup()` was called and the user timed out their response, the error would be caught but would continue to auth the user

Fixed:
- closed popup if it opened
- return should prevent false auth