### PR TITLE
Add auth0Client to context

### DIFF
--- a/01-Login/src/react-auth0-spa.js
+++ b/01-Login/src/react-auth0-spa.js
@@ -70,6 +70,7 @@ export const Auth0Provider = ({
   return (
     <Auth0Context.Provider
       value={{
+        auth0Client,
         isAuthenticated,
         user,
         loading,


### PR DESCRIPTION
If you do not add auth0Client here then it will always return undefined if you try to use it in your own hooks.

I saw some notes in the forums that this was an issue and of course ran into it myself:
https://community.auth0.com/t/auth0client-is-undefined/27202