### PR TITLE
Remove environment variables step from quickstart

### DIFF
--- a/quickstart/markdown/add-provider-variables.md
+++ b/quickstart/markdown/add-provider-variables.md
@@ -1,1 +1,0 @@
-In the root directory of your project, create or update the `%ENV_FILE_NAME%` file with the following variables.

--- a/quickstart/quickstart-login.yaml
+++ b/quickstart/quickstart-login.yaml
@@ -40,7 +40,6 @@ placeholders:
     inputKey: "appDomain"
   "%APP_SCHEME%":
     inputKey: "appScheme"
-  "%ENV_FILE_NAME%": *defaultEnvFileName
   "{import.meta.env.VITE_AUTH0_DOMAIN}":
     inputKey: "auth0Domain"
     prefix: '"'

--- a/quickstart/quickstart-login.yaml
+++ b/quickstart/quickstart-login.yaml
@@ -41,6 +41,14 @@ placeholders:
   "%APP_SCHEME%":
     inputKey: "appScheme"
   "%ENV_FILE_NAME%": *defaultEnvFileName
+  "{import.meta.env.VITE_AUTH0_DOMAIN}":
+    inputKey: "auth0Domain"
+    prefix: '"'
+    suffix: '"'
+  "{import.meta.env.VITE_AUTH0_CLIENT_ID}":
+    inputKey: "auth0ClientId"
+    prefix: '"'
+    suffix: '"'
 
 snippets:
   get-app: &getApp
@@ -99,12 +107,6 @@ steps:
         source: "quickstart/markdown/install-sdk.md"
       - type: terminal
         <<: *installAuth0
-  - title: "Define Auth0 Environment Variables"
-    contentBlocks:
-      - type: markdown
-        source: "quickstart/markdown/add-provider-variables.md"
-      - type: snippet
-        <<: *env
   - title: "Wrap your App with the Auth0Provider"
     contentBlocks:
       - type: markdown


### PR DESCRIPTION
This PR simplifies the quickstart by removing the separate environment variables setup step.

## Changes
- Remove 'Define Auth0 Environment Variables' step from the quickstart flow
- Add placeholder support for inline Auth0 domain and client ID replacement
- Delete the add-provider-variables.md markdown file that is no longer needed

## Motivation
Streamlines the quickstart process by eliminating a manual configuration step.